### PR TITLE
Add global vertex fast sim

### DIFF
--- a/submit/pass2/rundir/Fun4All_G4_Pileup.C
+++ b/submit/pass2/rundir/Fun4All_G4_Pileup.C
@@ -5,6 +5,7 @@
 
 #include <G4_OutputManager_Pileup.C>
 #include <G4_Production.C>
+#include <G4_Global.C>
 
 #include <fun4all/Fun4AllDstOutputManager.h>
 #include <fun4all/Fun4AllServer.h>
@@ -37,6 +38,26 @@ int Fun4All_G4_Pileup(
   Enable::PRODUCTION = true;
   Enable::DSTOUT = true;
   DstOut::OutputDir = outdir;
+
+  Enable::GLOBAL_FASTSIM = true;
+
+  //-----------------
+  // Global Vertexing
+  //-----------------
+
+  if (Enable::GLOBAL_RECO && Enable::GLOBAL_FASTSIM)
+  {
+    cout << "You can only enable Enable::GLOBAL_RECO or Enable::GLOBAL_FASTSIM, not both" << endl;
+    gSystem->Exit(1);
+  }
+  if (Enable::GLOBAL_RECO)
+  {
+    Global_Reco();
+  }
+  else if (Enable::GLOBAL_FASTSIM)
+  {
+    Global_FastSim();
+  }
 
   pair<int, int> runseg = Fun4AllUtils::GetRunSegment(inputFile);
   int runnumber = runseg.first;

--- a/submit/pass2/rundir/G4_OutputManager_Pileup.C
+++ b/submit/pass2/rundir/G4_OutputManager_Pileup.C
@@ -57,6 +57,13 @@ void CreateDstOutput(int runnumber, int segment)
   out->AddNode("PHHepMCGenEventMap");
   se->registerOutputManager(out);
   OUTPUTMANAGER::outfiles.insert(FullOutFile);
+
+  FullOutFile = DstOut::OutputDir + "/" + "DST_FASTSIM_GLOBAL_VERTEX_sHijing_0_12fm-" + segrun + ".root";;
+  out = new Fun4AllDstOutputManager("VERTEXOUT", FullOutFile);
+  AddCommonNodes(out);
+  out->AddNode("GlobalVertexMap");
+  se->registerOutputManager(out);
+  OUTPUTMANAGER::outfiles.insert(FullOutFile);
 }
 
 void AddCommonNodes(Fun4AllOutputManager *out)


### PR DESCRIPTION
Following today's meeting, this is just to test the idea of adding a fast sim of the truth vertex to the global vertex map, so it can be used consistently in calorimeter and jet reco. It is used to emulate a well reconstructed SvtxVertex, but with a fixed performance as coded in the default `G4_Global.C`/`Global_FastSim()`. The output DST stream should be small enough that can be easily used in later passes. 

* In this pull request, the implementation is at pass2 before the truth info is separated out. 
* Alternative implementation is to add it in pass3 pre-tracking stage with 
https://github.com/sPHENIX-Collaboration/MDC1/compare/main...blackcathj:GlobalVertexPatch?expand=1 
for which the file management could be more confusing while avoiding running pass2 again with the current sample. 
* It can also be its own pass reading in the truth container and output the global vertex DST, which is fast to run although use large memory and IO. 

