### PR TITLE
Heavy flavor: min-bias production macro

### DIFF
--- a/submit/HF_pp200_signal/condor/outdir.txt
+++ b/submit/HF_pp200_signal/condor/outdir.txt
@@ -1,1 +1,1 @@
-/sphenix/user/cdean/MDC1/pythia8/HeavyFlavorTG/data/minBias
+/pnfs/rcf.bnl.gov/sphenix/disk/MDC1/HF_pp200_signal

--- a/submit/HF_pp200_signal/condor/outdir.txt
+++ b/submit/HF_pp200_signal/condor/outdir.txt
@@ -1,1 +1,1 @@
-/pnfs/rcf.bnl.gov/sphenix/disk/MDC1/HF_pp200_signal
+/sphenix/user/cdean/MDC1/pythia8/HeavyFlavorTG/data/minBias

--- a/submit/HF_pp200_signal/condor/run_all.pl
+++ b/submit/HF_pp200_signal/condor/run_all.pl
@@ -10,7 +10,7 @@ my $incremental;
 GetOptions("test"=>\$test, "increment"=>\$incremental);
 if ($#ARGV < 1)
 {
-    print "usage: run_all.pl <number of jobs> <\"Charm\" or \"Bottom\" production>\n";
+    print "usage: run_all.pl <number of jobs> <\"Charm\", \"Bottom\ or \"minBias\" production>\n";
     print "parameters:\n";
     print "--increment : submit jobs while processing running\n";
     print "--test : dryrun - create jobfiles\n";
@@ -27,9 +27,9 @@ if ($hostname !~ /phnxsub/)
 
 my $maxsubmit = $ARGV[0];
 my $quarkfilter = $ARGV[1];
-if ($quarkfilter  ne "Charm" && $quarkfilter  ne "Bottom")
+if ($quarkfilter  ne "Charm" && $quarkfilter  ne "Bottom" && $quarkfilter  ne "minBias")
 {
-    print "second argument has to be either Charm or Bottom\n";
+    print "second argument has to be either Charm, Bottom or minBias\n";
     exit(1);
 }
 my $runnumber = 1;

--- a/submit/HF_pp200_signal/condor/run_all.pl
+++ b/submit/HF_pp200_signal/condor/run_all.pl
@@ -10,7 +10,7 @@ my $incremental;
 GetOptions("test"=>\$test, "increment"=>\$incremental);
 if ($#ARGV < 1)
 {
-    print "usage: run_all.pl <number of jobs> <\"Charm\", \"Bottom\ or \"minBias\" production>\n";
+    print "usage: run_all.pl <number of jobs> <\"Charm\", \"Bottom\ or \"MinBias\" production>\n";
     print "parameters:\n";
     print "--increment : submit jobs while processing running\n";
     print "--test : dryrun - create jobfiles\n";
@@ -27,9 +27,9 @@ if ($hostname !~ /phnxsub/)
 
 my $maxsubmit = $ARGV[0];
 my $quarkfilter = $ARGV[1];
-if ($quarkfilter  ne "Charm" && $quarkfilter  ne "Bottom" && $quarkfilter  ne "minBias")
+if ($quarkfilter  ne "Charm" && $quarkfilter  ne "Bottom" && $quarkfilter  ne "MinBias")
 {
-    print "second argument has to be either Charm, Bottom or minBias\n";
+    print "second argument has to be either Charm, Bottom or MinBias\n";
     exit(1);
 }
 my $runnumber = 1;

--- a/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
+++ b/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
@@ -84,7 +84,7 @@ int Fun4All_G4_HF_pp_signal(
   // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
   // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
   //Input::EMBED = true;
-  INPUTEMBED::filename = embed_input_file;
+  //INPUTEMBED::filename = embed_input_file; //Why is this complaining in local production? no .c_str()?
 
   // Input::SIMPLE = true;
   // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
@@ -143,7 +143,17 @@ int Fun4All_G4_HF_pp_signal(
     }
     else if (HF_Q_filter == "minBias")
     {
-      continue;
+      for (int i = 1; i < 7; ++i)
+      { //Trigger on any quark
+        p8_hf_signal_trigger -> AddParticles(i);
+        p8_hf_signal_trigger -> AddParticles(-1*i);
+      } 
+
+      for (int i = 21; i < 25; ++i)
+      {//Trigger on gluons, photons and vector bosons (valence/sea annihilation?)
+        p8_hf_signal_trigger -> AddParticles(i);
+      }
+        p8_hf_signal_trigger -> AddParticles(-24); //Trigger on W-
     }
     else
     {

--- a/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
+++ b/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
@@ -141,7 +141,6 @@ int Fun4All_G4_HF_pp_signal(
       p8_hf_signal_trigger -> AddParticles(5);
       p8_hf_signal_trigger -> AddParticles(-5);
     }
-
     else if (HF_Q_filter == "minBias")
     {
     /*

--- a/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
+++ b/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
@@ -38,7 +38,7 @@ R__LOAD_LIBRARY(libfun4all.so)
 
 int Fun4All_G4_HF_pp_signal(
     const int nEvents = 1,
-    const string &HF_Q_filter = "Charm", // or "Bottom"
+    const string &HF_Q_filter = "Charm", // or "Bottom" or "minBias"
     const string &outputFile = "G4sPHENIX.root",
     const string &embed_input_file = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
     const int skip = 0,
@@ -140,6 +140,10 @@ int Fun4All_G4_HF_pp_signal(
     {
       p8_hf_signal_trigger -> AddParticles(5);
       p8_hf_signal_trigger -> AddParticles(-5);
+    }
+    else if (HF_Q_filter == "minBias")
+    {
+      continue;
     }
     else
     {

--- a/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
+++ b/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
@@ -38,7 +38,7 @@ R__LOAD_LIBRARY(libfun4all.so)
 
 int Fun4All_G4_HF_pp_signal(
     const int nEvents = 1,
-    const string &HF_Q_filter = "Charm", // or "Bottom" or "minBias"
+    const string &HF_Q_filter = "Charm", // or "Bottom" or "MinBias"
     const string &outputFile = "G4sPHENIX.root",
     const string &embed_input_file = "https://www.phenix.bnl.gov/WWW/publish/phnxbld/sPHENIX/files/sPHENIX_G4Hits_sHijing_9-11fm_00000_00010.root",
     const int skip = 0,

--- a/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
+++ b/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
@@ -75,7 +75,7 @@ int Fun4All_G4_HF_pp_signal(
   // the simulations step completely. The G4Setup macro is only loaded to get information
   // about the number of layers used for the cell reco code
   //  Input::READHITS = true;
-  // INPUTREADHITS::filename = inputFile;
+  // INPUTREADHITS::filename[0] = inputFile;
 
   // Or:
   // Use particle generator
@@ -84,7 +84,7 @@ int Fun4All_G4_HF_pp_signal(
   // In case embedding into a production output, please double check your G4Setup_sPHENIX.C and G4_*.C consistent with those in the production macro folder
   // E.g. /sphenix/sim//sim01/production/2016-07-21/single_particle/spacal2d/
   //Input::EMBED = true;
-  //INPUTEMBED::filename = embed_input_file; //Why is this complaining in local production? no .c_str()?
+  //INPUTEMBED::filename[0] = embed_input_file;
 
   // Input::SIMPLE = true;
   // Input::SIMPLE_NUMBER = 2; // if you need 2 of them
@@ -141,7 +141,7 @@ int Fun4All_G4_HF_pp_signal(
       p8_hf_signal_trigger -> AddParticles(5);
       p8_hf_signal_trigger -> AddParticles(-5);
     }
-    else if (HF_Q_filter == "minBias")
+    else if (HF_Q_filter == "MinBias")
     {
     /*
       for (int i = 1; i < 7; ++i)

--- a/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
+++ b/submit/HF_pp200_signal/rundir/Fun4All_G4_HF_pp_signal.C
@@ -141,8 +141,10 @@ int Fun4All_G4_HF_pp_signal(
       p8_hf_signal_trigger -> AddParticles(5);
       p8_hf_signal_trigger -> AddParticles(-5);
     }
+
     else if (HF_Q_filter == "minBias")
     {
+    /*
       for (int i = 1; i < 7; ++i)
       { //Trigger on any quark
         p8_hf_signal_trigger -> AddParticles(i);
@@ -154,6 +156,7 @@ int Fun4All_G4_HF_pp_signal(
         p8_hf_signal_trigger -> AddParticles(i);
       }
         p8_hf_signal_trigger -> AddParticles(-24); //Trigger on W-
+    */
     }
     else
     {
@@ -165,7 +168,7 @@ int Fun4All_G4_HF_pp_signal(
     p8_hf_signal_trigger->PrintConfig();
 //    p8_hf_signal_trigger->Verbosity(10);
 
-    INPUTGENERATOR::Pythia8->register_trigger(p8_hf_signal_trigger);
+    if (HF_Q_filter == "Charm" or HF_Q_filter == "Bottom") INPUTGENERATOR::Pythia8->register_trigger(p8_hf_signal_trigger);
     INPUTGENERATOR::Pythia8->set_vertex_distribution_function( PHHepMCGenHelper::Gaus, PHHepMCGenHelper::Gaus,PHHepMCGenHelper::Uniform ,PHHepMCGenHelper::Gaus);
     INPUTGENERATOR::Pythia8->set_vertex_distribution_width(0.1,0.1,10,0);
   }


### PR DESCRIPTION
This PR adds min-bias production functionality to the MDC1 package. This should run identically to the c-cbar and b-bbar production, just type "perl run_all.pl <nJobs> minBias"